### PR TITLE
[backend] feat(search): support defanged IOCs in global search

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/engine.js
+++ b/opencti-platform/opencti-graphql/src/database/engine.js
@@ -119,6 +119,7 @@ import { isSingleRelationsRef, } from '../schema/stixEmbeddedRelationship';
 import { now, runtimeFieldObservableValueScript } from '../utils/format';
 import { ENTITY_TYPE_KILL_CHAIN_PHASE, ENTITY_TYPE_MARKING_DEFINITION, isStixMetaObject } from '../schema/stixMetaObject';
 import { getEntitiesListFromCache, getEntityFromCache } from './cache';
+import { refang } from '../utils/refang';
 import { ENTITY_TYPE_MIGRATION_STATUS, ENTITY_TYPE_SETTINGS, ENTITY_TYPE_STATUS, ENTITY_TYPE_USER, isInternalObject } from '../schema/internalObject';
 import { meterManager, telemetry } from '../config/tracing';
 import {
@@ -1834,10 +1835,10 @@ function processSearch(search, args) {
   const { useWildcardPrefix = ES_DEFAULT_WILDCARD_PREFIX } = args;
   let decodedSearch;
   try {
-    decodedSearch = decodeURIComponent(search)
+    decodedSearch = decodeURIComponent(refang(search))
       .trim();
   } catch (e) {
-    decodedSearch = search.trim();
+    decodedSearch = refang(search).trim();
   }
   let remainingSearch = decodedSearch;
   const exactSearch = (decodedSearch.match(/"[^"]+"/g) || []) //

--- a/opencti-platform/opencti-graphql/src/utils/refang.js
+++ b/opencti-platform/opencti-graphql/src/utils/refang.js
@@ -1,0 +1,86 @@
+// Utility to refang defanged IOCs (Indicators of Compromise)
+// Supports common defanging techniques: [.] -> ., hxxp -> http, etc.
+
+import { URL } from 'url';
+
+/**
+ * Refang, clean, normalize, and optionally truncate an indicator value for Defender API submission.
+ * - Refangs common obfuscations
+ * - Extracts and sanitizes URLs
+ * - Encodes path/query safely
+ * - Strips trailing garbage and punctuation
+ * @param {string} input - The potentially defanged string.
+ * @returns {string} - The refanged string.
+ */
+export function refang(input) {
+  if (!input || typeof input !== 'string') return input;
+
+  // Trim first
+  input = input.trim();
+
+  let output = input;
+
+  // Normalize Unicode (NFKC)
+  if (typeof output.normalize === 'function') {
+    output = output.normalize('NFKC');
+  }
+
+  // Refang common obfuscations (all patterns from both functions)
+  output = output
+    // Replace [.] and (.) and [dot] or (dot) with .
+    .replace(/\[(\.|dot)\]|\((\.|dot)\)/gi, '.')
+    // Replace [at] or (at) with @
+    .replace(/\[at\]|\(at\)/gi, '@')
+    // Replace [dash] or (dash) with -
+    .replace(/\[dash\]|\(dash\)/gi, '-')
+    // Replace hxxp/hxp/hxxps/hxps (with optional brackets/colons) -> http/https
+    .replace(/(\s*)h([x]{1,2})p([s]?)[\[\]:]*\/\//gi, (m, pre, xx, s) => `${pre}http${s}://`)
+    // Replace fxp/sfxp/fxps (with optional brackets/colons) -> ftp/ftps
+    .replace(/(\s*)(s?)fxp(s?)[\[\]:]*\/\//gi, (m, pre, s1, s2) => `${pre}${s1}ftp${s2}://`)
+    // Replace (protocol)[://] or similar -> protocol://
+    .replace(/(\s*)\(([-.+a-zA-Z0-9]{1,12})\)[\[\]:]*\/\//gi, (m, pre, proto) => `${pre}${proto}://`)
+    // Replace [://] or similar with ://
+    .replace(/\[:\/]{3,}/g, '://')
+    // Remove any stray brackets around single characters
+    .replace(/\[([a-zA-Z0-9])\]/g, '$1')
+    // Remove literal ellipsis character
+    .replace(/\u2026/g, '');
+
+  // Remove common placeholder endings (e.g., trailing [.] or ...)
+  output = output.replace(/(\[\.\]|\.{2,}|…)+$/g, '');
+
+  // Extract valid URL if present and sanitize
+  const urlMatch = output.match(/https?:\/\/[^\s'"<>]+/i);
+  if (urlMatch) {
+    try {
+      let extractedUrl = urlMatch[0];
+      // Clean trailing punctuation early
+      extractedUrl = extractedUrl.replace(/[.,;!?…]+$/, '');
+
+      const parsed = new URL(extractedUrl);
+      if (!parsed.protocol || !parsed.hostname) return null;
+
+      // Decode and normalize
+      let decodedPath = decodeURIComponent(parsed.pathname || '');
+      let decodedQuery = decodeURIComponent(parsed.search ? parsed.search.slice(1) : '');
+
+      // Remove dangerous or non-printable chars from path/query
+      decodedPath = decodedPath.replace(/[^\x20-\x7E/]/g, '');
+      decodedQuery = decodedQuery.replace(/[^\x20-\x7E\-=&]/g, '');
+
+      // Encode path/query safely
+      const safePath = encodeURI(decodedPath);
+      const safeQuery = encodeURIComponent(decodedQuery).replace(/%3D/g, '=').replace(/%26/g, '&');
+
+      // Rebuild URL
+      output = parsed.protocol + '//' + parsed.hostname +
+        (safePath.startsWith('/') ? safePath : '/' + safePath) +
+        (safeQuery ? '?' + safeQuery : '');
+    } catch (e) {
+      // On URL parse error, return the original input (not null)
+      return input;
+    }
+  }
+
+  return output;
+}


### PR DESCRIPTION
- Detects and refangs common defanging techniques (such as square brackets in IOCs) before processing global search queries. This allows analysts to paste defanged indicators directly into search without manual refanging, improving usability and accuracy.

Resolves #3142, Resolves #8799, Resolves #11213

### Proposed changes

* Adds a refang utility function
* Uses the refang utility in processSearch() to decode defanged searches

### Related issues

* Issue #3142
* Issue #8799
* Issue 11213

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

- refang() is implemented in a utility function so it can be used in other places also.